### PR TITLE
Add cstdint to includes and fix const member access bug

### DIFF
--- a/common/include/quantile_sketch_sorted_view.hpp
+++ b/common/include/quantile_sketch_sorted_view.hpp
@@ -20,6 +20,7 @@
 #ifndef QUANTILE_SKETCH_SORTED_VIEW_HPP_
 #define QUANTILE_SKETCH_SORTED_VIEW_HPP_
 
+#include <cstdint>
 #include <functional>
 
 namespace datasketches {

--- a/common/include/quantile_sketch_sorted_view_impl.hpp
+++ b/common/include/quantile_sketch_sorted_view_impl.hpp
@@ -21,6 +21,7 @@
 #define QUANTILE_SKETCH_SORTED_VIEW_IMPL_HPP_
 
 #include <algorithm>
+#include <cstdint>
 #include <stdexcept>
 
 namespace datasketches {

--- a/common/include/serde.hpp
+++ b/common/include/serde.hpp
@@ -20,6 +20,7 @@
 #ifndef DATASKETCHES_SERDE_HPP_
 #define DATASKETCHES_SERDE_HPP_
 
+#include <cstdint>
 #include <cstring>
 #include <iostream>
 #include <memory>

--- a/fi/include/reverse_purge_hash_map.hpp
+++ b/fi/include/reverse_purge_hash_map.hpp
@@ -20,6 +20,7 @@
 #ifndef REVERSE_PURGE_HASH_MAP_HPP_
 #define REVERSE_PURGE_HASH_MAP_HPP_
 
+#include <cstdint>
 #include <memory>
 #include <iterator>
 

--- a/python/src/vector_of_kll.cpp
+++ b/python/src/vector_of_kll.cpp
@@ -123,16 +123,16 @@ vector_of_kll_sketches<T,C,S>::vector_of_kll_sketches(vector_of_kll_sketches&& o
 template<typename T, typename C, typename S>
 vector_of_kll_sketches<T,C,S>& vector_of_kll_sketches<T,C,S>::operator=(const vector_of_kll_sketches& other) {
   vector_of_kll_sketches<T,C,S> copy(other);
-  k_ = copy.k_;
-  d_ = copy.d_;
+  k_ = copy.get_k();
+  d_ = copy.get_d();
   std::swap(sketches_, copy.sketches_);
   return *this;
 }
 
 template<typename T, typename C, typename S>
 vector_of_kll_sketches<T,C,S>& vector_of_kll_sketches<T,C,S>::operator=(vector_of_kll_sketches&& other) {
-  k_ = other.k_;
-  d_ = other.d_;
+  k_ = other.get_k();
+  d_ = other.get_d();
   std::swap(sketches_, other.sketches_);
   return *this;
 }


### PR DESCRIPTION
This build is breaking on my GCC 15.2.1 system due to the `uint32_t` and other `cstdint`-defined numeric types requiring `#include <cstdint>` in order to be defined.

The `cstdint` header has been around since C++11, so this should be fairly backward-compatible with even 10-year-old C++ compilers.

Another compiling issue I ran into was that the `python/src/vector_of_kll.cpp` was directly accessing the `k_`/`d_` values from the local copy of the RHS value made in the assignment calls. Converted these to using the `const` accessor methods instead.